### PR TITLE
fixed Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.7.1-alpine3.8
+FROM python:3.7.2-alpine3.9
 
 RUN python3 -m ensurepip --upgrade
 RUN python3 -m pip install python-telegram
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl libstdc++
 
 ADD ./examples/*.py /app/examples/


### PR DESCRIPTION
The Docker container was not working for me because of this reasons:
1. wrong openssl (version 1.0 instead of 1.1) installed
2. no stdc++ lib installed

had to update to a newer python version (3.7.2) and could use a newer alpine version (3.9).
Now it is working for me without any problems.

Please update docker hub when merged. Thx!