### PR TITLE
fix for a race between async request registering and sending

### DIFF
--- a/telegram/client.py
+++ b/telegram/client.py
@@ -358,9 +358,8 @@ class Telegram:
 
         async_result = AsyncResult(client=self, result_id=result_id)
         data['@extra']['request_id'] = async_result.id
-
-        self._tdjson.send(data)
         self._results[async_result.id] = async_result
+        self._tdjson.send(data)
         async_result.request = data
 
         if block:


### PR DESCRIPTION
apparently solves a major issue with hanging on async_result.wait()