### PR TITLE
Fix #67: Client waits for the next authorization state only for messages with id=updateAuthorizationState

### DIFF
--- a/telegram/utils.py
+++ b/telegram/utils.py
@@ -1,9 +1,13 @@
 import uuid
 import threading
+import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
     from telegram.client import Telegram  # noqa  pylint: disable=cyclic-import
+
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncResult:
@@ -41,12 +45,18 @@ class AsyncResult:
             raise RuntimeError(f'Telegram error: {self.error_info}')
 
     def parse_update(self, update: Dict[Any, Any]) -> None:
-        if update.get('@type') == 'ok':
-            self.ok_received = True
-            self._ready.set()
-            return False
+        update_type = update.get('@type')
 
-        if update.get('@type') == 'error':
+        logger.debug('update id=%s type=%s received', self.id, update_type)
+
+        if update_type == 'ok':
+            self.ok_received = True
+            if self.id == 'updateAuthorizationState':
+                # For updateAuthorizationState commands tdlib sends
+                # @type: ok responses
+                # but we want to wait longer to receive the new authorization state
+                return False
+        elif update_type == 'error':
             self.error = True
             self.error_info = update
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,6 +36,7 @@ class TestAsyncResult:
         assert async_result.error_info == update
         assert async_result.update is None
         assert async_result.ok_received is False
+        assert async_result._ready.is_set() is True
 
     def test_parse_update_ok(self):
         async_result = AsyncResult(client=None)
@@ -47,6 +48,27 @@ class TestAsyncResult:
         assert async_result.error_info is None
         assert async_result.update is None
         assert async_result.ok_received is True
+        assert async_result._ready.is_set() is True
+
+    def test_parse_update_authorization_state_ok(self):
+        # when id=updateAuthorizationState
+        # and @type=ok
+        # it should not set async_result._ready
+        # because for updateAuthorizationState we want to wait for the
+        # next message with result_id=updateAuthorizationState
+        async_result = AsyncResult(
+            client=None,
+            result_id='updateAuthorizationState',
+        )
+        update = {'@type': 'ok', 'some': 'data'}
+
+        async_result.parse_update(update)
+
+        assert async_result.error is False
+        assert async_result.error_info is None
+        assert async_result.update is None
+        assert async_result.ok_received is True
+        assert async_result._ready.is_set() is False
 
     def test_parse_update(self):
         async_result = AsyncResult(client=None)
@@ -58,6 +80,7 @@ class TestAsyncResult:
         assert async_result.error_info is None
         assert async_result.update == update
         assert async_result.ok_received is False
+        assert async_result._ready.is_set() is True
 
     def test_wait_with_timeout(self):
         async_result = AsyncResult(client=None)


### PR DESCRIPTION
Fix #67: Client waits for the next authorization state only for messages with id=updateAuthorizationState