### PR TITLE
Fix find_library call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 build
+python_telegram.egg-info
 .tdlib_files
 .tdlib_files*
 .tox

--- a/telegram/tdjson.py
+++ b/telegram/tdjson.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_tdjson_lib_path() -> str:
-    system_library = ctypes.util.find_library("libtdjson")
+    system_library = ctypes.util.find_library("tdjson")
 
     if system_library is not None:
         return system_library

--- a/tests/test_tdjson.py
+++ b/tests/test_tdjson.py
@@ -7,49 +7,47 @@ class TestGetTdjsonTdlibPath:
     def test_for_darwin(self):
         mocked_system = Mock(return_value='Darwin')
         mocked_resource = Mock()
+        mocked_find_library = Mock(return_value=None)
 
         with patch('telegram.tdjson.platform.system', mocked_system):
-            with patch(
-                'telegram.tdjson.pkg_resources.resource_filename', mocked_resource
-            ):
-                _get_tdjson_lib_path()
+            with patch('telegram.tdjson.pkg_resources.resource_filename', mocked_resource):
+                with patch('telegram.tdjson.ctypes.util.find_library', mocked_find_library):
+                    _get_tdjson_lib_path()
 
-        mocked_resource.assert_called_once_with(
-            'telegram', 'lib/darwin/libtdjson.dylib'
-        )
+        mocked_resource.assert_called_once_with('telegram', 'lib/darwin/libtdjson.dylib')
 
     def test_for_linux(self):
         mocked_system = Mock(return_value='Linux')
         mocked_resource = Mock(return_value='/tmp/')
+        mocked_find_library = Mock(return_value=None)
 
         with patch('telegram.tdjson.platform.system', mocked_system):
-            with patch(
-                'telegram.tdjson.pkg_resources.resource_filename', mocked_resource
-            ):
-                _get_tdjson_lib_path()
+            with patch('telegram.tdjson.pkg_resources.resource_filename', mocked_resource):
+                with patch('telegram.tdjson.ctypes.util.find_library', mocked_find_library):
+                    _get_tdjson_lib_path()
 
         mocked_resource.assert_called_once_with('telegram', 'lib/linux/libtdjson.so')
 
     def test_for_windows(self):
         mocked_system = Mock(return_value='Windows')
         mocked_resource = Mock(return_value='/tmp/')
+        mocked_find_library = Mock(return_value=None)
 
         with patch('telegram.tdjson.platform.system', mocked_system):
-            with patch(
-                'telegram.tdjson.pkg_resources.resource_filename', mocked_resource
-            ):
-                _get_tdjson_lib_path()
+            with patch('telegram.tdjson.pkg_resources.resource_filename', mocked_resource):
+                with patch('telegram.tdjson.ctypes.util.find_library', mocked_find_library):
+                    _get_tdjson_lib_path()
 
         mocked_resource.assert_called_once_with('telegram', 'lib/linux/libtdjson.so')
 
     def test_unknown(self):
         mocked_system = Mock(return_value='Unknown')
         mocked_resource = Mock(return_value='/tmp/')
+        mocked_find_library = Mock(return_value=None)
 
         with patch('telegram.tdjson.platform.system', mocked_system):
-            with patch(
-                'telegram.tdjson.pkg_resources.resource_filename', mocked_resource
-            ):
-                _get_tdjson_lib_path()
+            with patch('telegram.tdjson.pkg_resources.resource_filename', mocked_resource):
+                with patch('telegram.tdjson.ctypes.util.find_library', mocked_find_library):
+                    _get_tdjson_lib_path()
 
         mocked_resource.assert_called_once_with('telegram', 'lib/linux/libtdjson.so')


### PR DESCRIPTION
`find_library("libtdjson")` is unable to find libtdjson.so, as it searches for liblibtdjson.so, as stated in documentation to the function.

As `find_library` has never found a system installed library, it always defaulted to a project one. 4 tests broke, as they did not mock `find_library` call to return *None* value. After unsuccessful attempt to find system installed library, function `_get_tdjson_lib_path` checks system type and selects correct version of project tdjson library. On my machine tdjson library is installed system wide, so call to `find_library` does not return *None* value, and 4 tests fails to check project library selection.