### PR TITLE
Rename description-file to description_file; fixes #340

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
Dash separated values is deprecated in setuptools and will not be supported soon.