### PR TITLE
chat-history max limit is 100

### DIFF
--- a/telegram/client.py
+++ b/telegram/client.py
@@ -386,7 +386,7 @@ class Telegram:
     def get_chat_history(
         self,
         chat_id: int,
-        limit: int = 1000,
+        limit: int = 100,
         from_message_id: int = 0,
         offset: int = 0,
         only_local: bool = False,


### PR DESCRIPTION
https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_history.html#ad5c6852c24b3b39c48321496871a637b
> The maximum number of messages to be returned; must be positive and can't be greater than 100. If the offset is negative, the limit must be greater than or equal to -offset. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit.