### PR TITLE
Reject a request when its id is already in flight

### DIFF
--- a/telegram/client.py
+++ b/telegram/client.py
@@ -619,6 +619,18 @@ class Telegram:
         if not result_id and "request_id" in data["@extra"]:
             result_id = data["@extra"]["request_id"]
 
+        if result_id:
+            pending = self._results.get(result_id)
+
+            if pending is not None and not pending._ready.is_set():
+                # Overwriting the entry would leave `pending` unreachable from
+                # `_update_async_result`, so nothing would ever resolve it and
+                # anyone waiting on it would block forever.
+                raise RuntimeError(
+                    f"A request with id={result_id} is already in flight. "
+                    "Authorization calls share a fixed request id, so they cannot be made concurrently."
+                )
+
         async_result = AsyncResult(client=self, result_id=result_id)
         data["@extra"]["request_id"] = async_result.id
         self._results[async_result.id] = async_result
@@ -828,7 +840,9 @@ class Telegram:
             "type": self.proxy_type,
         }
 
-        return self._send_data(data, result_id="setProxy")
+        # no fixed result_id: the result is never awaited, and `login` may send
+        # this more than once while a previous addProxy is still in flight
+        return self._send_data(data)
 
     def _send_bot_token(self) -> AsyncResult:
         logger.info("Sending bot token")

--- a/tests/test_telegram_methods.py
+++ b/tests/test_telegram_methods.py
@@ -425,6 +425,38 @@ class TestTelegram__update_async_result:
         assert new_async_result.id == "updateAuthorizationState"
 
 
+class TestTelegram__send_data:
+    def test_raises_if_a_request_with_the_same_id_is_in_flight(self, telegram):
+        first = telegram._send_data({"@type": "checkAuthenticationCode"}, result_id="updateAuthorizationState")
+
+        with pytest.raises(RuntimeError, match="already in flight"):
+            telegram._send_data({"@type": "checkAuthenticationPassword"}, result_id="updateAuthorizationState")
+
+        # the pending result must stay reachable, otherwise nothing can resolve it
+        assert telegram._results["updateAuthorizationState"] is first
+
+    def test_reuses_the_id_after_the_previous_request_is_resolved(self, telegram):
+        telegram._send_data({"@type": "checkAuthenticationCode"}, result_id="updateAuthorizationState")
+        telegram._update_async_result(
+            {
+                "@type": "updateAuthorizationState",
+                "authorization_state": {"@type": "authorizationStateReady"},
+            }
+        )
+
+        second = telegram._send_data({"@type": "checkAuthenticationPassword"}, result_id="updateAuthorizationState")
+
+        assert telegram._results["updateAuthorizationState"] is second
+
+    def test_add_proxy_can_be_sent_repeatedly(self, telegram):
+        telegram.proxy_server = "example.com"
+
+        first = telegram._send_add_proxy()
+        second = telegram._send_add_proxy()
+
+        assert first.id != second.id
+
+
 class TestTelegram__login:
     def test_login_process_should_do_nothing_if_already_authorized(self, telegram):
         telegram.authorization_state = AuthorizationState.READY


### PR DESCRIPTION
Authorization calls all share the fixed request id "updateAuthorizationState", and _send_data replaced the entry in _results without checking it. Two overlapping calls left the first AsyncResult unreachable from _update_async_result, so nothing could resolve it and whoever waited on it blocked forever without a log line.

Raise on a result that has not resolved yet, so the caller gets a named error instead of a hang.