### PR TITLE
Make stopping the client safe

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,8 @@ Changelog
 - Added support for Python 3.13 and 3.14.
 - Login no longer fails with a ``ValueError`` when tdlib reports an authorization state that ``AuthorizationState`` did not know about: ``authorizationStateWaitEmailAddress``, ``authorizationStateWaitEmailCode``, ``authorizationStateWaitOtherDeviceConfirmation`` and ``authorizationStateLoggingOut``.
 - Added email authorization support: ``send_email_address`` and ``send_email_code``.
+- ``stop`` no longer blocks forever when tdlib does not answer, and no longer leaves the client running when tdlib answers with an error. It now waits up to 5 seconds for the session to close, which can be changed with ``stop(close_timeout=...)``.
+- Calling a method after ``stop`` raises ``ClientDestroyedError`` instead of crashing the process. The destroyed tdlib handle was passed to the C library as a ``NULL`` pointer.
 
 [0.19.0] - 2024-06-23
 ---------------------

--- a/telegram/client.py
+++ b/telegram/client.py
@@ -21,7 +21,7 @@ from typing import (
 )
 
 from telegram import VERSION
-from telegram.tdjson import TDJson
+from telegram.tdjson import ClientDestroyedError, TDJson
 from telegram.text import Element
 from telegram.utils import AsyncResult
 from telegram.worker import BaseWorker, SimpleWorker
@@ -30,6 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 MESSAGE_HANDLER_TYPE: str = "updateNewMessage"
+
+# how long `stop` waits for tdlib to report the CLOSED authorization state
+DEFAULT_CLOSE_TIMEOUT: float = 5.0
 
 
 class AuthorizationState(enum.Enum):
@@ -147,17 +150,30 @@ class Telegram:
         if login:
             self.login()
 
-    def stop(self) -> None:
-        """Stops the client"""
+    def stop(self, close_timeout: float = DEFAULT_CLOSE_TIMEOUT) -> None:
+        """
+        Stops the client.
+
+        Args:
+            close_timeout: how long to wait for tdlib to close the session
+                before shutting down anyway
+        """
 
         if self._stopped.is_set():
             return
 
         logger.info("Stopping telegram client...")
 
-        self._close()
-        self.worker.stop()
+        try:
+            self._close(timeout=close_timeout)
+        except Exception:
+            # a broken or unresponsive tdlib must not prevent the shutdown:
+            # everything below has to run, otherwise `idle` never returns,
+            # the listener thread keeps going and the tdlib client leaks
+            logger.exception("Could not close the tdlib session cleanly, stopping anyway")
+
         self._stopped.set()
+        self.worker.stop()
 
         # wait for the tdjson listener to stop
         self._td_listener.join()
@@ -165,16 +181,29 @@ class Telegram:
         if hasattr(self, "_tdjson"):
             self._tdjson.stop()
 
-    def _close(self) -> None:
+    def _close(self, timeout: float = DEFAULT_CLOSE_TIMEOUT) -> None:
         """
         Calls `close` tdlib method and waits until authorization_state becomes CLOSED.
-        Blocking.
+
+        Blocking, but gives up after `timeout` seconds.
         """
         self.call_method("close")
 
+        deadline = time.monotonic() + timeout
+
         while self.authorization_state != AuthorizationState.CLOSED:
+            time_left = deadline - time.monotonic()
+
+            if time_left <= 0:
+                logger.warning(
+                    "tdlib has not reached the CLOSED state in %s seconds, last known state: %s",
+                    timeout,
+                    self.authorization_state,
+                )
+                return
+
             result = self.get_authorization_state()
-            self.authorization_state = self._wait_authorization_result(result)
+            self.authorization_state = self._wait_authorization_result(result, timeout=time_left)
             logger.info("Authorization state: %s", self.authorization_state)
             time.sleep(0.5)
 
@@ -545,6 +574,10 @@ class Telegram:
                 if update:
                     self._update_async_result(update)
                     self._run_handlers(update)
+            except ClientDestroyedError:
+                # nothing left to listen to, and retrying would spin
+                logger.info("[Telegram.td_listener] the tdlib client is gone, stopping")
+                break
             except Exception:
                 if self._stopped.is_set():
                     break
@@ -670,11 +703,11 @@ class Telegram:
 
         return self._send_data(data, result_id="getAuthorizationState")
 
-    def _wait_authorization_result(self, result: AsyncResult) -> AuthorizationState:
+    def _wait_authorization_result(self, result: AsyncResult, timeout: float | None = None) -> AuthorizationState:
         authorization_state = None
 
         if result:
-            result.wait(raise_exc=True)
+            result.wait(timeout=timeout, raise_exc=True)
 
             if result.update is None:
                 raise RuntimeError("Something wrong, the result update is None")

--- a/telegram/tdjson.py
+++ b/telegram/tdjson.py
@@ -11,6 +11,10 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+class ClientDestroyedError(RuntimeError):
+    """Raised when a TDJson client is used after it has been stopped"""
+
+
 def _get_tdjson_lib_path() -> str:
     system_library = ctypes.util.find_library("tdjson")
 
@@ -45,7 +49,7 @@ class TDJson:
         self._td_json_client_create.restype = c_void_p
         self._td_json_client_create.argtypes = []
 
-        self.td_json_client = self._td_json_client_create()
+        self.td_json_client: int | None = self._td_json_client_create()
 
         self._td_json_client_receive = self._tdjson.td_json_client_receive
         self._td_json_client_receive.restype = c_char_p
@@ -90,13 +94,25 @@ class TDJson:
         self._c_on_fatal_error_callback = fatal_error_callback_type(on_fatal_error_callback)
         self._td_set_log_fatal_error_callback(self._c_on_fatal_error_callback)
 
+    def _get_client(self) -> int:
+        """
+        Returns the client handle, or raises if the client has been destroyed.
+
+        tdlib dereferences this handle, so passing a destroyed (NULL) one
+        crashes the whole process instead of raising.
+        """
+        if self.td_json_client is None:
+            raise ClientDestroyedError("The tdlib client is stopped and cannot be used anymore")
+
+        return self.td_json_client
+
     def send(self, query: dict[Any, Any]) -> None:
         dumped_query = json.dumps(query).encode("utf-8")
-        self._td_json_client_send(self.td_json_client, dumped_query)
+        self._td_json_client_send(self._get_client(), dumped_query)
         logger.debug("[me ==>] Sent %s", dumped_query)
 
     def receive(self) -> None | dict[Any, Any]:
-        result_str = self._td_json_client_receive(self.td_json_client, 1.0)
+        result_str = self._td_json_client_receive(self._get_client(), 1.0)
 
         if result_str:
             result: dict[Any, Any] = json.loads(result_str.decode("utf-8"))
@@ -108,7 +124,7 @@ class TDJson:
 
     def td_execute(self, query: dict[Any, Any]) -> dict[Any, Any] | Any:
         dumped_query = json.dumps(query).encode("utf-8")
-        result_str = self._td_json_client_execute(self.td_json_client, dumped_query)
+        result_str = self._td_json_client_execute(self._get_client(), dumped_query)
 
         if result_str:
             result: dict[Any, Any] = json.loads(result_str.decode("utf-8"))

--- a/telegram/utils.py
+++ b/telegram/utils.py
@@ -36,7 +36,7 @@ class AsyncResult:
     def __str__(self) -> str:
         return f"AsyncResult <{self.id}>"
 
-    def wait(self, timeout: int | None = None, raise_exc: bool = False) -> None:
+    def wait(self, timeout: float | None = None, raise_exc: bool = False) -> None:
         """
         Blocking method to wait for the result
         """

--- a/tests/test_tdjson.py
+++ b/tests/test_tdjson.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from telegram.tdjson import TDJson, _get_tdjson_lib_path
 
 
@@ -71,6 +73,25 @@ class TestTDJson:
         tdjson.stop()
         tdjson.stop()
         tdjson._td_json_client_destroy.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("method", "args"),
+        [
+            ("send", ({"@type": "getAuthorizationState"},)),
+            ("receive", ()),
+            ("td_execute", ({"@type": "getAuthorizationState"},)),
+        ],
+    )
+    def test_methods_raise_after_stop(self, method, args):
+        tdjson = self._make_tdjson()
+        tdjson.stop()
+
+        with pytest.raises(RuntimeError, match="stopped"):
+            getattr(tdjson, method)(*args)
+
+        tdjson._td_json_client_send.assert_not_called()
+        tdjson._td_json_client_receive.assert_not_called()
+        tdjson._td_json_client_execute.assert_not_called()
 
     def test_fatal_error_callback_stored_on_instance(self):
         tdjson = self._make_tdjson()

--- a/tests/test_telegram_methods.py
+++ b/tests/test_telegram_methods.py
@@ -1,4 +1,6 @@
 import queue
+import threading
+import time
 from unittest.mock import patch
 
 import pytest
@@ -628,6 +630,85 @@ class TestWorkerExceptionHandling:
         assert results == [{"@type": "test"}]
 
 
+class TestStop:
+    # the `telegram` fixture patches `threading`, so `_stopped` has to be a real
+    # event for these tests, and `_td_listener` stays a mock
+
+    def _prepare(self, telegram):
+        telegram._stopped = threading.Event()
+        telegram.authorization_state = AuthorizationState.READY
+
+    def test_stop_is_idempotent(self, telegram):
+        self._prepare(telegram)
+        telegram._stopped.set()
+
+        telegram.stop()
+
+        telegram._tdjson.stop.assert_not_called()
+
+    def test_stop_finishes_when_tdlib_does_not_answer(self, telegram):
+        self._prepare(telegram)
+
+        started = time.monotonic()
+        telegram.stop(close_timeout=0.2)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 3
+        assert telegram._stopped.is_set()
+        telegram._td_listener.join.assert_called_once()
+        telegram._tdjson.stop.assert_called_once()
+
+    def test_stop_finishes_when_tdlib_returns_an_error(self, telegram):
+        self._prepare(telegram)
+
+        def answer_with_error(data):
+            async_result = telegram._results.get(data["@extra"]["request_id"])
+            if async_result:
+                async_result.parse_update({"@type": "error", "code": 400, "message": "boom"})
+
+        telegram._tdjson.send.side_effect = answer_with_error
+
+        telegram.stop()
+
+        assert telegram._stopped.is_set()
+        telegram._td_listener.join.assert_called_once()
+        telegram._tdjson.stop.assert_called_once()
+
+    def test_stop_finishes_when_close_raises(self, telegram):
+        self._prepare(telegram)
+
+        with patch.object(telegram, "_close", side_effect=RuntimeError("boom")):
+            telegram.stop()
+
+        assert telegram._stopped.is_set()
+        telegram._tdjson.stop.assert_called_once()
+
+    def test_close_stops_waiting_after_the_timeout(self, telegram):
+        self._prepare(telegram)
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            telegram._close(timeout=0.2)
+
+        assert time.monotonic() - started < 3
+
+    def test_close_does_not_wait_at_all_with_a_zero_timeout(self, telegram):
+        self._prepare(telegram)
+
+        telegram._close(timeout=0)
+
+        # only the `close` request itself, no authorization state polling
+        assert telegram._tdjson.send.call_count == 1
+
+    def test_close_returns_when_the_state_is_already_closed(self, telegram):
+        self._prepare(telegram)
+        telegram.authorization_state = AuthorizationState.CLOSED
+
+        telegram._close()
+
+        assert telegram._tdjson.send.call_count == 1
+
+
 class TestListenerExceptionHandling:
     def test_listener_survives_receive_exception(self, telegram):
         import threading
@@ -649,6 +730,23 @@ class TestListenerExceptionHandling:
         telegram._listen_to_td()
 
         assert call_count == 3
+
+    def test_listener_exits_when_the_client_is_destroyed(self, telegram):
+        from telegram.tdjson import ClientDestroyedError
+
+        telegram._stopped = threading.Event()
+        call_count = 0
+
+        def destroyed_receive():
+            nonlocal call_count
+            call_count += 1
+            raise ClientDestroyedError("stopped")
+
+        telegram._tdjson.receive = destroyed_receive
+        telegram._listen_to_td()
+
+        # it breaks out instead of spinning on the same error
+        assert call_count == 1
 
     def test_listener_exits_on_exception_when_stopped(self, telegram):
         import threading


### PR DESCRIPTION
Fixes two ways `stop()` can break the client.

`_close()` waits for the `CLOSED` authorization state with no timeout and `raise_exc=True`. When tdlib does not answer, `stop()` blocks forever. When it answers with an error, the exception escapes before `self._stopped.set()`, so `idle()` never returns, the listener thread keeps running and the tdlib client is never destroyed.

`TDJson.stop()` sets `td_json_client` to `None`, but `send`, `receive` and `td_execute` kept passing it to tdlib. ctypes turns `None` into `NULL` and [tdlib dereferences it](https://github.com/tdlib/td/blob/master/td/telegram/td_json_client.cpp), so any call after `stop()` killed the process instead of raising. They now raise `ClientDestroyedError`, and the listener thread breaks out of its loop on it instead of spinning.